### PR TITLE
Fix unused block error

### DIFF
--- a/ctregex.zig
+++ b/ctregex.zig
@@ -518,7 +518,7 @@ const RegexParser = struct {
 
         fn minLen(comptime self: SubExpr, comptime encoding: Encoding) usize {
             switch (self) {
-                .atom => |atom| block: {
+                .atom => |atom| {
                     const atom_min_len = atom.data.minLen(encoding);
                     switch (atom.mod) {
                         .char => |c| if (c == '*' or c == '?') return 0,


### PR DESCRIPTION
Currently the tests fail with this error repeatedly spammed in the console. The issue is fixed with this commit.
```zig
./ctregex.zig:521:40: error: unused block label
                .atom => |atom| block: {
```
I'm aware @kivikakk's WIP fork fixes this too, but it doesn't compile on my end so I wanted to at least get the "original" version compiling :)